### PR TITLE
ロケットハッシュの修正

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,8 +3,7 @@
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
-    = javascript_include_tag 'application', 'data-turbolinks-track' => true
-    = csrf_meta_tags
+    = stylesheet_link_tag    'application', media: 'all', data: { turbolinks: { track: true }}
+    = javascript_include_tag 'application', data: { turbolinks: { track: true }}
   %body
     = yield


### PR DESCRIPTION
# What
ロケットハッシュの修正

# Why
記法が古いため